### PR TITLE
Refactor embedded cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Restore cached dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v2.1.4
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
         node-version: [12.x, 14.x]
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2.3.4
       - name: Use Node.js
         uses: actions/setup-node@v2.1.4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2.1.4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Restore cached dependencies

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install jwks-fetch
 const buildJwksFetch = require('jwks-fetch')
 
 
-const jwksFetch = await buildJwksFetch()
+const jwksFetch = buildJwksFetch()
 
 const secret = await jwksFetch.getSecret({
   domain: 'https://exampe.com/',
@@ -34,7 +34,7 @@ jwksFetch.clearCache()
 
 ### getSecret
 
-Calling `jwksFetch.getSecret` will fetch the [JSON Web Key](https://tools.ietf.org/html/rfc7517), Set and verify if any of the public keys matches the `alg` and `kid` values of your JWT token.  And it will cache the secret so if called again, it will not make another http request but return the cached secret.
+Calling `jwksFetch.getSecret` will fetch the [JSON Web Key](https://tools.ietf.org/html/rfc7517), Set and verify if any of the public keys matches the `alg` and `kid` values of your JWT token.  And it will cache the secret so if called again it will not make another http request to return the secret.
 
 - `domain`: A string containing the domain (ie: `https://www.example.com/`) from which the library should fetch the JWKS. `jwks-fetch` will add the JWKS location (`.well-known/jwks.json`) to form the final url (ie: `https://www.example.com/.well-known/jwks.json`).
 - `alg`: The alg header parameter represents the cryptographic algorithm used to secure the token. You will find it in your decoded JWT.
@@ -55,8 +55,8 @@ const buildJwksFetch = require('jwks-fetch')
 
 
 const jwksFetch = await buildJwksFetch({
-  max: Number,
-  ttl: Number
+  max: 500,
+  ttl: 60 * 1000
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Clears the contents of the cache
 
 ### Optional cache constuctor
 
-When creating the cache contructor you pass some optional parameters based off the [tiny-lru](https://www.npmjs.com/package/tiny-lru) package.
+When creating the cache constructor you pass some optional parameters based off the [tiny-lru](https://www.npmjs.com/package/tiny-lru) package.
 - `max`: Max items to hold in cache, the default setting is 100.
 - `ttl`: Milliseconds an item will remain in cache; lazy expiration upon next get() of an item, the default setting is 60000.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Clears the contents of the cache
 
 ### Optional cache constuctor
 
-When creating the cache contructor you pass some optional parameters based off the tiny-lru package
+When creating the cache contructor you pass some optional parameters based off the [tiny-lru package](https://www.npmjs.com/package/tiny-lru#max).
 - `max`: Max items to hold in cache, the default setting is 100.
 - `ttl`: Milliseconds an item will remain in cache; lazy expiration upon next get() of an item, the default setting is 60000.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jwksFetch.clearCache()
 
 ### getSecret
 
-Calling the `jwksFetch.getSecret` will fetch the [JSON Web Key](https://tools.ietf.org/html/rfc7517), Set and verify if any of the public keys matches the `alg` and `kid` values of your JWT token.  And it will cache the secret so if called again it will not make another http request to return the secret.  It is asynchronous.
+Calling the `getSecret` will fetch the [JSON Web Key](https://tools.ietf.org/html/rfc7517), Set and verify if any of the public keys matches the `alg` and `kid` values of your JWT token.  And it will cache the secret so if called again it will not make another http request to return the secret.  It is asynchronous.
 
 - `domain`: A string containing the domain (ie: `https://www.example.com/`) from which the library should fetch the JWKS. `jwks-fetch` will add the JWKS location (`.well-known/jwks.json`) to form the final url (ie: `https://www.example.com/.well-known/jwks.json`).
 - `alg`: The alg header parameter represents the cryptographic algorithm used to secure the token. You will find it in your decoded JWT.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ npm install jwks-fetch
 ```javascript
 const buildJwksFetch = require('jwks-fetch')
 
-
 const jwksFetch = buildJwksFetch()
 
 const secret = await jwksFetch.getSecret({
@@ -34,7 +33,7 @@ jwksFetch.clearCache()
 
 ### getSecret
 
-Calling `jwksFetch.getSecret` will fetch the [JSON Web Key](https://tools.ietf.org/html/rfc7517), Set and verify if any of the public keys matches the `alg` and `kid` values of your JWT token.  And it will cache the secret so if called again it will not make another http request to return the secret.
+Calling the `jwksFetch.getSecret` will fetch the [JSON Web Key](https://tools.ietf.org/html/rfc7517), Set and verify if any of the public keys matches the `alg` and `kid` values of your JWT token.  And it will cache the secret so if called again it will not make another http request to return the secret.  It is asynchronous.
 
 - `domain`: A string containing the domain (ie: `https://www.example.com/`) from which the library should fetch the JWKS. `jwks-fetch` will add the JWKS location (`.well-known/jwks.json`) to form the final url (ie: `https://www.example.com/.well-known/jwks.json`).
 - `alg`: The alg header parameter represents the cryptographic algorithm used to secure the token. You will find it in your decoded JWT.
@@ -53,8 +52,7 @@ When creating the cache contructor you pass some optional parameters based off t
 ```javascript
 const buildJwksFetch = require('jwks-fetch')
 
-
-const jwksFetch = await buildJwksFetch({
+const jwksFetch = buildJwksFetch({
   max: 500,
   ttl: 60 * 1000
 })

--- a/README.md
+++ b/README.md
@@ -15,45 +15,49 @@ npm install jwks-fetch
 ## Usage
 
 ```javascript
-const jwksFetch = require('jwks-fetch')
+const buildJwksFetch = require('jwks-fetch')
 
 
-cosnt secret = await jwksFetch({
+const jwksFetch = await buildJwksFetch()
+
+const secret = await jwksFetch.getSecret({
   domain: 'https://exampe.com/',
   alg: 'token_alg',
   kid: 'token_kid'
 })
 
-// if you want to use a cache to not fetch the JWKS every time
+// to clear the secret in cache
+jwksFetch.clearCache()
 
-const NodeCache = require('node-cache')
-const cache = new NodeCache()
-cosnt secret = await jwksFetch({
-  domain: 'https://exampe.com/',
-  alg: 'token_alg',
-  kid: 'token_kid',
-  cache
-})
 ```
 
 
-### jwksFetch
+### getSecret
 
-Calling `jwksFetch` will fetch the [JSON Web Key](https://tools.ietf.org/html/rfc7517) Set and verify if any of the publi keys matches the `alg` and `kid` values of your JWT token.
+Calling `jwksFetch.getSecret` will fetch the [JSON Web Key](https://tools.ietf.org/html/rfc7517), Set and verify if any of the public keys matches the `alg` and `kid` values of your JWT token.  And it will cache the secret so if called again, it will not make another http request but return the cached secret.
 
 - `domain`: A string containing the domain (ie: `https://www.example.com/`) from which the library should fetch the JWKS. `jwks-fetch` will add the JWKS location (`.well-known/jwks.json`) to form the final url (ie: `https://www.example.com/.well-known/jwks.json`).
 - `alg`: The alg header parameter represents the cryptographic algorithm used to secure the token. You will find it in your decoded JWT.
 - `kid`: The kid is a hint that indicates which key was used to secure the JSON web signature of the token. You will find it in your decoded JWT.
-- `cache`: This is an optional parameter. You can provide a cache (ie: [NodeCache](https://github.com/node-cache/node-cache)) implementation for jwksFetch.
 
-#### How `jwks-fetch` uses the `cache` parameter
+### clearCache
 
-If the `cache` parameter is provided, `jwks-fetch` will first look for a matching public key in the cache.
+Clears the contents of the cache
 
-If a match is found, it will be returned.
+### Optional cache constuctor
 
-If no match is found, `jwks-fetch` will try to fetch the JWKS from the given `domain`.
+When creating the cache contructor you pass some optional parameters based off the tiny-lru package
+- `max`: Max items to hold in cache, the default setting is 100.
+- `ttl`: Milliseconds an item will remain in cache; lazy expiration upon next get() of an item, the default setting is 60000.
 
-Once the JWKS is fetched, `jwks-fetch` will look for a matching public key, and if found it will save it in the cache and return it.
+```javascript
+const buildJwksFetch = require('jwks-fetch')
 
-If a matching key is not found, even after fetching from the JWKS, `jwks-fetch` flags that particular combination of `domain`/`alg`/`kid` as "missing" (saving `null` in the cache). Until the specific cache key is not deleted, `jwks-fetch` will not try to fetch again the JWKS for that particular combination.
+
+const jwksFetch = await buildJwksFetch({
+  max: Number,
+  ttl: Number
+})
+```
+
+

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Clears the contents of the cache
 
 ### Optional cache constuctor
 
-When creating the cache contructor you pass some optional parameters based off the [tiny-lru package](https://www.npmjs.com/package/tiny-lru#max).
+When creating the cache contructor you pass some optional parameters based off the [tiny-lru](https://www.npmjs.com/package/tiny-lru) package.
 - `max`: Max items to hold in cache, the default setting is 100.
 - `ttl`: Milliseconds an item will remain in cache; lazy expiration upon next get() of an item, the default setting is 60000.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -749,12 +749,12 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.19.0.tgz",
-      "integrity": "sha512-CGlMgJY56JZ9ZSYhJuhow61lMPPjUzWmChFya71Z/jilVos7mR/jPgaEfVGgMBY5DshbKdG8Ezb8FDCHcoMEMg==",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.20.0.tgz",
+      "integrity": "sha512-qGi0CTcOGP2OtCQBgWZlQjcTuP0XkIpYFj25XtRTQSHC+umNnp7UMshr2G8SLsRFYDdAPFeHOsiteadmMH02Yw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
+        "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.3.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -766,7 +766,7 @@
         "eslint-utils": "^2.1.0",
         "eslint-visitor-keys": "^2.0.0",
         "espree": "^7.3.1",
-        "esquery": "^1.2.0",
+        "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "file-entry-cache": "^6.0.0",
         "functional-red-black-tree": "^1.0.1",
@@ -793,6 +793,15 @@
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+          "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
@@ -2998,9 +3007,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.4.tgz",
-          "integrity": "sha512-xzzzaqgEQfmuhbhAoqjJ8T/1okb6gAzXn/eQRNpAN1AEUoHJTNF9xCDRTtf/s3SKldtZfa+RJeTs+BQq+eZ/sw==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.1.0.tgz",
+          "integrity": "sha512-svS9uILze/cXbH0z2myCK2Brqprx/+JJYK5pHicT/GQiBfzzhUVAIT6MwqJg8y4xV/zoGsUeuPuwtoiKSGE15g==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4290,6 +4290,11 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "tiny-lru": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-7.0.6.tgz",
+      "integrity": "sha512-zNYO0Kvgn5rXzWpL0y3RS09sMK67eGaQj9805jlK9G6pSadfriTczzLHFXa/xcW4mIRfmlB9HyQ/+SgL0V1uow=="
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {
-    "eslint": "^7.19.0",
+    "eslint": "^7.20.0",
     "eslint-config-standard": "^16.0.2",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jwks-fetch",
   "version": "1.0.0",
   "description": "Fetch utils for JWKS keys",
-  "main": "index.js",
+  "main": "src/jwks-fetch.js",
   "scripts": {
     "test": "tap",
     "lint": "eslint src/**/*.js test/**/*.js",
@@ -23,7 +23,8 @@
   },
   "homepage": "https://github.com/nearform/jwks-fetch#readme",
   "dependencies": {
-    "node-fetch": "^2.6.1"
+    "node-fetch": "^2.6.1",
+    "tiny-lru": "^7.0.6"
   },
   "devDependencies": {
     "eslint": "^7.20.0",

--- a/src/jwks-fetch.js
+++ b/src/jwks-fetch.js
@@ -3,16 +3,14 @@
 const fetch = require('node-fetch')
 const lru = require('tiny-lru')
 
-const MISSING_KEY_ERROR = 'No matching key found in the set.';
+const MISSING_KEY_ERROR = 'No matching key found in the set.'
 
 function buildJwksFetch (cacheProps = {}) {
+  const max = cacheProps.max || 100
+  const ttl = cacheProps.ttl || 60 * 1000
+  const cache = lru(max, ttl)
 
-  const max = cacheProps.max || 100;
-  const ttl = cacheProps.ttl || 60 * 1000;
-  const cache = lru(max, ttl);
-
-  async function getSecret(signatures) {
-
+  async function getSecret (signatures) {
     const { domain, alg, kid } = signatures
     const cacheKey = `${alg}:${kid}:${domain}`
     const cached = cache.get(cacheKey)
@@ -63,7 +61,6 @@ function buildJwksFetch (cacheProps = {}) {
     getSecret: getSecret,
     cache
   }
-
 }
 
 module.exports = buildJwksFetch

--- a/src/jwks-fetch.js
+++ b/src/jwks-fetch.js
@@ -59,6 +59,7 @@ function buildJwksFetch (cacheProps = {}) {
 
   return {
     getSecret: getSecret,
+    clearCache: () => cache.clear(),
     cache
   }
 }

--- a/src/jwks-fetch.js
+++ b/src/jwks-fetch.js
@@ -4,6 +4,7 @@ const fetch = require('node-fetch')
 const lru = require('tiny-lru')
 
 const MISSING_KEY_ERROR = 'No matching key found in the set.'
+const NO_KEYS_ERROR = 'No keys found in the set.'
 
 function buildJwksFetch (cacheProps = {}) {
   const max = cacheProps.max || 100
@@ -35,7 +36,7 @@ function buildJwksFetch (cacheProps = {}) {
     }
 
     if (!body.keys || body.keys.length === 0) {
-      throw new Error('No keys found in the set.')
+      throw new Error(NO_KEYS_ERROR)
     }
 
     // Find the key with ID and algorithm matching the JWT token header

--- a/src/jwks-fetch.js
+++ b/src/jwks-fetch.js
@@ -13,11 +13,11 @@ function buildJwksFetch (cacheProps = {}) {
   async function getSecret (signatures) {
     const { domain, alg, kid } = signatures
     const cacheKey = `${alg}:${kid}:${domain}`
-    const cached = cache.get(cacheKey)
+    const cachedSecret = cache.get(cacheKey)
 
-    if (cached) {
-      return cached
-    } else if (cached === null) {
+    if (cachedSecret) {
+      return cachedSecret
+    } else if (cachedSecret === null) {
       // null is returned when a previous attempt resulted in the key missing in the JWKs - Do not attemp to fetch again
       throw new Error(MISSING_KEY_ERROR)
     }

--- a/src/jwks-fetch.js
+++ b/src/jwks-fetch.js
@@ -1,54 +1,67 @@
 'use strict'
 
 const fetch = require('node-fetch')
-const MISSING_KEY_ERROR = 'No matching key found in the set.'
-const NO_KEYS_ERROR = 'No keys found in the set.'
+const lru = require('tiny-lru')
 
-async function jwksFetch ({ domain, alg, kid, cache = null }) {
-  const cacheKey = `${alg}:${kid}:${domain}`
+const MISSING_KEY_ERROR = 'No matching key found in the set.';
 
-  const cached = cache ? cache.get(cacheKey) : null
+async function buildJwksFetch (cacheProps = { max: 100, ttl: 60 * 1000 }) {
 
-  if (cached) {
-    return cached
-  } else if (cache && cached === null) {
-    // null is returned when a previous attempt resulted in the key missing in the JWKs - Do not attemp to fetch again
-    throw new Error(MISSING_KEY_ERROR)
+  const cache = lru(cacheProps.max, cacheProps.ttl);
+
+  async function getSecret(signatures) {
+
+    const { domain, alg, kid } = signatures
+    const cacheKey = `${alg}:${kid}:${domain}`
+    const cached = cache.get(cacheKey)
+
+    if (cached) {
+      return cached
+    } else if (cached === null) {
+      // null is returned when a previous attempt resulted in the key missing in the JWKs - Do not attemp to fetch again
+      throw new Error(MISSING_KEY_ERROR)
+    }
+
+    // Hit the well-known URL in order to get the key
+    const response = await fetch(`${domain}.well-known/jwks.json`, { timeout: 5000 })
+    const body = await response.json()
+
+    if (!response.ok) {
+      const error = new Error(response.statusText)
+      error.response = response
+      error.body = body
+
+      throw error
+    }
+
+    if (!body.keys || body.keys.length === 0) {
+      throw new Error('No keys found in the set.')
+    }
+
+    // Find the key with ID and algorithm matching the JWT token header
+    const key = body.keys.find(k => k.alg === alg && k.kid === kid)
+
+    if (!key) {
+      // Mark the key as missing
+      cache.set(cacheKey, null)
+      throw new Error(MISSING_KEY_ERROR)
+    }
+
+    // should we be using https://github.com/Brightspace/node-jwk-to-pem ??
+
+    // certToPEM extracted from https://github.com/auth0/node-jwks-rsa/blob/master/src/utils.js
+    const secret = `-----BEGIN CERTIFICATE-----\n${key.x5c[0]}\n-----END CERTIFICATE-----\n`
+
+    // Save the key in the cache
+    cache.set(cacheKey, secret)
+    return secret
   }
 
-  // Hit the well-known URL in order to get the key
-  const response = await fetch(`${domain}.well-known/jwks.json`, { timeout: 5000 })
-  const body = await response.json()
-
-  if (!response.ok) {
-    const error = new Error(response.statusText)
-    error.response = response
-    error.body = body
-
-    throw error
+  return {
+    getSecret: getSecret,
+    cache
   }
 
-  if (!body.keys || body.keys.length === 0) {
-    throw new Error(NO_KEYS_ERROR)
-  }
-
-  // Find the key with ID and algorithm matching the JWT token header
-  const key = body.keys.find(k => k.alg === alg && k.kid === kid)
-
-  if (!key) {
-    // Mark the key as missing
-    cache && cache.set(cacheKey, null)
-    throw new Error(MISSING_KEY_ERROR)
-  }
-
-  // should we be using https://github.com/Brightspace/node-jwk-to-pem ??
-
-  // certToPEM extracted from https://github.com/auth0/node-jwks-rsa/blob/master/src/utils.js
-  const secret = `-----BEGIN CERTIFICATE-----\n${key.x5c[0]}\n-----END CERTIFICATE-----\n`
-
-  // Save the key in the cache
-  cache && cache.set(cacheKey, secret)
-  return secret
 }
 
-module.exports = jwksFetch
+module.exports = buildJwksFetch

--- a/src/jwks-fetch.js
+++ b/src/jwks-fetch.js
@@ -5,9 +5,11 @@ const lru = require('tiny-lru')
 
 const MISSING_KEY_ERROR = 'No matching key found in the set.';
 
-async function buildJwksFetch (cacheProps = { max: 100, ttl: 60 * 1000 }) {
+function buildJwksFetch (cacheProps = {}) {
 
-  const cache = lru(cacheProps.max, cacheProps.ttl);
+  const max = cacheProps.max || 100;
+  const ttl = cacheProps.ttl || 60 * 1000;
+  const cache = lru(max, ttl);
 
   async function getSecret(signatures) {
 

--- a/test/jwks.spec.js
+++ b/test/jwks.spec.js
@@ -20,7 +20,7 @@ t.test('should fetch the remove jwks and return an error if the request fails', 
   t.plan(2)
   nock('https://localhost/').get('/.well-known/jwks.json').reply(500, { msg: 'no good' })
   try {
-    const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 });
+    const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 })
     await jwksFetch.getSecret({ domain: 'https://localhost/', alg: 'RS512', kid: 'KEY' })
   } catch (e) {
     t.equal(e.message, 'Internal Server Error')
@@ -33,7 +33,7 @@ t.test('should fetch the remove jwks and return an error if alg and kid do not m
   t.plan(1)
   nock('https://localhost/').get('/.well-known/jwks.json').reply(200, jwks)
   try {
-    const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 });
+    const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 })
     await jwksFetch.getSecret({ domain: 'https://localhost/', alg: 'ABC', kid: 'some other KEY' })
   } catch (e) {
     t.equal(e.message, 'No matching key found in the set.')
@@ -44,7 +44,7 @@ t.test('should fetch the remove jwks and return an error if alg and kid do not m
 t.test('should fetch the remove jwks and return an the secrete if alg and kid match', async t => {
   t.plan(2)
   nock('https://localhost/').get('/.well-known/jwks.json').reply(200, jwks)
-  const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 });
+  const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 })
   const secret = await jwksFetch.getSecret({ domain: 'https://localhost/', alg: 'RS512', kid: 'KEY' })
   t.ok(secret)
   t.includes(secret, jwks.keys[0].x5c[0])
@@ -54,7 +54,7 @@ t.test('should fetch the remove jwks and return an the secrete if alg and kid ma
 t.test('if the cached key is null it would return an error', async t => {
   t.plan(1)
 
-  const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 });
+  const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 })
   const domain = 'https://localhost/'
   const alg = 'ABC'
   const kid = 'key'
@@ -73,7 +73,7 @@ t.test('if alg and kid do not match any jwks, the cache key should be set to nul
   t.plan(2)
   nock('https://localhost/').get('/.well-known/jwks.json').reply(200, jwks)
 
-  const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 });
+  const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 })
   const domain = 'https://localhost/'
   const alg = 'ALG'
   const kid = 'KEY'
@@ -92,7 +92,7 @@ t.test('if alg and kid do not match any jwks, the cache key should be set to nul
 t.test('if the cached key is undefined it should fetch the jwks and set the key to the secret', async t => {
   t.plan(3)
   nock('https://localhost/').get('/.well-known/jwks.json').reply(200, jwks)
-  const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 });
+  const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 })
   const domain = 'https://localhost/'
   const alg = 'RS512'
   const kid = 'KEY'
@@ -108,7 +108,7 @@ t.test('if the cached key is undefined it should fetch the jwks and set the key 
 t.test('if the cached key has a value it should return that value', async t => {
   t.plan(3)
   nock('https://localhost/').get('/.well-known/jwks.json').reply(200, jwks)
-  const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 });
+  const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 })
   const domain = 'https://localhost/'
   const alg = 'RS512'
   const kid = 'KEY'
@@ -130,7 +130,7 @@ t.test('it will throw an error id no keys are found in the JWKS', async t => {
   const kid = 'KEY'
 
   try {
-    const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 });
+    const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 })
     await jwksFetch.getSecret({ domain, alg, kid })
   } catch (e) {
     t.equal(e.message, 'No keys found in the set.')
@@ -147,7 +147,7 @@ t.test('it will throw an error id no keys are found in the JWKS', async t => {
   const kid = 'KEY'
 
   try {
-    const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 });
+    const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 })
     await jwksFetch.getSecret({ domain, alg, kid })
   } catch (e) {
     t.equal(e.message, 'No keys found in the set.')

--- a/test/jwks.spec.js
+++ b/test/jwks.spec.js
@@ -70,7 +70,7 @@ t.test('if the cached key is null it would return an error', async t => {
   t.end()
 })
 
-t.test('if a cache is present and alg and kid do not match any jwks, the cache key should be set to null', async t => {
+t.test('if alg and kid do not match any jwks, the cache key should be set to null', async t => {
   t.plan(2)
   nock('https://localhost/').get('/.well-known/jwks.json').reply(200, jwks)
 
@@ -90,7 +90,7 @@ t.test('if a cache is present and alg and kid do not match any jwks, the cache k
   t.end()
 })
 
-t.test('if a cache is present and the cached key is undefined it should fetch the jwks and set the key to the secret', async t => {
+t.test('if the cached key is undefined it should fetch the jwks and set the key to the secret', async t => {
   t.plan(3)
   nock('https://localhost/').get('/.well-known/jwks.json').reply(200, jwks)
   const jwksFetch = await buildJwksFetch({ max: 100, ttl: 60 * 1000 });
@@ -106,7 +106,7 @@ t.test('if a cache is present and the cached key is undefined it should fetch th
   t.end()
 })
 
-t.test('if a cache is present and the cached key has a value it should return that value', async t => {
+t.test('if the cached key has a value it should return that value', async t => {
   t.plan(3)
   nock('https://localhost/').get('/.well-known/jwks.json').reply(200, jwks)
   const jwksFetch = await buildJwksFetch({ max: 100, ttl: 60 * 1000 });

--- a/test/jwks.spec.js
+++ b/test/jwks.spec.js
@@ -156,6 +156,19 @@ t.test('it will throw an error id no keys are found in the JWKS', async t => {
   t.end()
 })
 
+t.test('if initializes without any cache settings it should use default values', async t => {
+  t.plan(3)
+  nock('https://localhost/').get('/.well-known/jwks.json').reply(200, jwks)
+
+  const jwksFetch = buildJwksFetch()
+  const cache = jwksFetch.cache
+
+  t.ok(jwksFetch.cache)
+  t.equal(cache.max, 100)
+  t.equal(cache.ttl, 60000)
+  t.end()
+})
+
 const jwks = {
   keys: [
     {

--- a/test/jwks.spec.js
+++ b/test/jwks.spec.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const NodeCache = require('node-cache')
 const nock = require('nock')
 const t = require('tap')
 
@@ -21,7 +20,7 @@ t.test('should fetch the remove jwks and return an error if the request fails', 
   t.plan(2)
   nock('https://localhost/').get('/.well-known/jwks.json').reply(500, { msg: 'no good' })
   try {
-    const jwksFetch = await buildJwksFetch({ max: 100, ttl: 60 * 1000 });
+    const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 });
     await jwksFetch.getSecret({ domain: 'https://localhost/', alg: 'RS512', kid: 'KEY' })
   } catch (e) {
     t.equal(e.message, 'Internal Server Error')
@@ -34,7 +33,7 @@ t.test('should fetch the remove jwks and return an error if alg and kid do not m
   t.plan(1)
   nock('https://localhost/').get('/.well-known/jwks.json').reply(200, jwks)
   try {
-    const jwksFetch = await buildJwksFetch({ max: 100, ttl: 60 * 1000 });
+    const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 });
     await jwksFetch.getSecret({ domain: 'https://localhost/', alg: 'ABC', kid: 'some other KEY' })
   } catch (e) {
     t.equal(e.message, 'No matching key found in the set.')
@@ -45,7 +44,7 @@ t.test('should fetch the remove jwks and return an error if alg and kid do not m
 t.test('should fetch the remove jwks and return an the secrete if alg and kid match', async t => {
   t.plan(2)
   nock('https://localhost/').get('/.well-known/jwks.json').reply(200, jwks)
-  const jwksFetch = await buildJwksFetch({ max: 100, ttl: 60 * 1000 });
+  const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 });
   const secret = await jwksFetch.getSecret({ domain: 'https://localhost/', alg: 'RS512', kid: 'KEY' })
   t.ok(secret)
   t.includes(secret, jwks.keys[0].x5c[0])
@@ -55,7 +54,7 @@ t.test('should fetch the remove jwks and return an the secrete if alg and kid ma
 t.test('if the cached key is null it would return an error', async t => {
   t.plan(1)
 
-  const jwksFetch = await buildJwksFetch({ max: 100, ttl: 60 * 1000 });
+  const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 });
   const domain = 'https://localhost/'
   const alg = 'ABC'
   const kid = 'key'
@@ -74,7 +73,7 @@ t.test('if alg and kid do not match any jwks, the cache key should be set to nul
   t.plan(2)
   nock('https://localhost/').get('/.well-known/jwks.json').reply(200, jwks)
 
-  const jwksFetch = await buildJwksFetch({ max: 100, ttl: 60 * 1000 });
+  const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 });
   const domain = 'https://localhost/'
   const alg = 'ALG'
   const kid = 'KEY'
@@ -93,7 +92,7 @@ t.test('if alg and kid do not match any jwks, the cache key should be set to nul
 t.test('if the cached key is undefined it should fetch the jwks and set the key to the secret', async t => {
   t.plan(3)
   nock('https://localhost/').get('/.well-known/jwks.json').reply(200, jwks)
-  const jwksFetch = await buildJwksFetch({ max: 100, ttl: 60 * 1000 });
+  const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 });
   const domain = 'https://localhost/'
   const alg = 'RS512'
   const kid = 'KEY'
@@ -109,7 +108,7 @@ t.test('if the cached key is undefined it should fetch the jwks and set the key 
 t.test('if the cached key has a value it should return that value', async t => {
   t.plan(3)
   nock('https://localhost/').get('/.well-known/jwks.json').reply(200, jwks)
-  const jwksFetch = await buildJwksFetch({ max: 100, ttl: 60 * 1000 });
+  const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 });
   const domain = 'https://localhost/'
   const alg = 'RS512'
   const kid = 'KEY'
@@ -131,7 +130,7 @@ t.test('it will throw an error id no keys are found in the JWKS', async t => {
   const kid = 'KEY'
 
   try {
-    const jwksFetch = await buildJwksFetch({ max: 100, ttl: 60 * 1000 });
+    const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 });
     await jwksFetch.getSecret({ domain, alg, kid })
   } catch (e) {
     t.equal(e.message, 'No keys found in the set.')
@@ -148,7 +147,7 @@ t.test('it will throw an error id no keys are found in the JWKS', async t => {
   const kid = 'KEY'
 
   try {
-    const jwksFetch = await buildJwksFetch({ max: 100, ttl: 60 * 1000 });
+    const jwksFetch = buildJwksFetch({ max: 100, ttl: 60 * 1000 });
     await jwksFetch.getSecret({ domain, alg, kid })
   } catch (e) {
     t.equal(e.message, 'No keys found in the set.')


### PR DESCRIPTION
Closes #14 

Breaking change

jwksFetch is created with an optional cache constructor, including `max` & `ttl` and returns 3 properties:

`jwksFetch.getSecret`
`jwksFetch.clearCache`
`jwksFetch.cache`  (the whole cache is only returned for use in tests, the proposal is just to expose a clearCache function)